### PR TITLE
docs(workflows-methodologies): add terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,20 @@ for more information.
 
 ## Topics covered
 
-- [API Fundamentals](https://rhyannonjoy.github.io/api-docs-glossary/docs/core-concepts#api-fundamentals): REST APIs, security
-- [Documentation-Specific Concepts](https://rhyannonjoy.github.io/api-docs-glossary/docs/core-concepts#documentation-specific-concepts): OpenAPI specification, overview topics
-- [Frameworks & Strategy](https://rhyannonjoy.github.io/api-docs-glossary/docs/frameworks-strategy): audience analysis, domain knowledge
-- [Tools & Techniques](https://rhyannonjoy.github.io/api-docs-glossary/docs/tools-techniques): cURL, Postman
-- [Processes](https://rhyannonjoy.github.io/api-docs-glossary/docs/processes): project management, usability testing
-- [Writing Style](https://rhyannonjoy.github.io/api-docs-glossary/docs/writing-style): content strategy, rhetorical approach
-- [AI & APIs](https://rhyannonjoy.github.io/api-docs-glossary/docs/ai-and-apis): artificial intelligence in API documentation
+- [API Fundamentals](https://rhyannonjoy.github.io/api-docs-glossary/docs/core-concepts#api-fundamentals):
+REST APIs, security
+- [Documentation-Specific Concepts](https://rhyannonjoy.github.io/api-docs-glossary/docs/core-concepts#documentation-specific-concepts):
+OpenAPI specification, overview topics
+- [Frameworks & Strategy](https://rhyannonjoy.github.io/api-docs-glossary/docs/frameworks-strategy):
+audience analysis, domain knowledge
+- [Tools & Techniques](https://rhyannonjoy.github.io/api-docs-glossary/docs/tools-techniques):
+cURL, Postman
+- [Workflows & Methodologies](https://rhyannonjoy.github.io/api-docs-glossary/docs/workflows-methodologies):
+project management, usability testing
+- [Writing Style](https://rhyannonjoy.github.io/api-docs-glossary/docs/writing-style):
+content strategy, rhetorical approach
+- [AI & APIs](https://rhyannonjoy.github.io/api-docs-glossary/docs/ai-and-apis):
+artificial intelligence in API documentation
 
 ## Getting started
 

--- a/docs/ai-and-apis.md
+++ b/docs/ai-and-apis.md
@@ -1,5 +1,42 @@
 # AI & APIs
 
-_coming soon_
-
 <!-- TODO: include Artificial intelligence in API documentation -->
+
+## AI-assisted usability analysis
+
+**Definition**: use of artificial intelligence tools to analyze
+usability test results and identify patterns in user behavior or
+interface issues
+
+**Purpose**: accelerates analysis of certain types of usability
+data while recognizing the limitations of AI in evaluating human
+factors
+
+**Appropriate use cases**:
+
+- Mechanical tests: language clarity, navigation patterns,
+consistency checks
+- Pattern identification: recurring user errors, common
+interaction sequences
+- Quantitative analysis: time-on-task, completion rates,
+click paths
+
+**Limitations**:
+
+- Cannot reliably assess human factors: credibility,
+perception, satisfaction, emotional responses
+- AI capabilities and best practices evolve rapidly, requiring
+ongoing evaluation
+- Results should supplement, not replace, human expertise in
+usability research
+- Interpretation quality depends on the specific AI tools and
+prompts used
+
+**Note**: this represents current perspectives on AI application
+to usability testing and may evolve as AI capabilities develop
+
+**Related Terms**: Guerrilla Usability Testing, usability testing
+
+**Source**: UW API Docs - Module 4, Lesson 3, "Review usability testing for API"
+
+---

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -1,5 +1,0 @@
-# Processes
-
-_coming soon_
-
-<!-- TODO: include Agile, DDLC, project management, guerilla usability testing -->

--- a/docs/workflows-methodologies.md
+++ b/docs/workflows-methodologies.md
@@ -1,0 +1,241 @@
+# Workflows & methodologies
+
+Development and documentation workflows for API projects. This section
+covers methodologies, testing approaches, and lifecycle management
+practices that guide how API documentation teams plan, create,
+validate, and maintain their work.
+
+## Agile
+
+**Definition**: methodology with a collection of project management
+frameworks that break projects down into smaller phases and
+rely on iterative cycles
+
+**Purpose**: allows teams to adapt to changes and regularly refine
+their work through flexibility rather than linear, rigid planning
+
+**Key Values**:
+
+- People over processes
+- Working solutions over detailed documentation
+- Customer collaboration over rigid contracts
+- Adapting to change over following a strict plan
+
+**Related Terms**: Document Development Life Cycle, project management
+methodology, Scrum, Waterfall
+
+**Sources**:
+
+- [Manifesto for Agile Software Development](https://agilemanifesto.org/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+- [What Is Agile Methodology in Project Management?](https://www.wrike.com/project-management-guide/faq/what-is-agile-methodology-in-project-management/)
+
+---
+
+## Critical Chain Project Management (CCPM)
+
+**Definition**: approach that focuses on resources needed to complete
+tasks rather than solely on task dependencies; takes the critical
+path method one step further
+
+**Purpose**: ensures project schedules account for resource constraints,
+not just task dependencies
+
+**Related Terms**: Agile, Critical Path Method, project management methodology
+
+**Sources**:
+
+- [Project Management Methodologies](https://www.wrike.com/project-management-guide/methodologies/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+
+---
+
+## Critical Path Method (CPM)
+
+**Definition**: project management technique identifying task sequences
+where some tasks can't start until previous ones finish, often visualized
+with Gantt charts
+
+**Purpose**: helps teams understand task dependencies and identify
+bottlenecks in project timelines
+
+**Example**: the "critical path" in a software release might include code
+freeze → QA testing → documentation review → deployment, where delays in
+any step delay the entire release
+
+**Related Terms**: Agile, Critical Chain Project Management,
+project management methodology
+
+**Sources**:
+
+- [A Gantt Chart Guide](https://www.projectmanager.com/guides/gantt-chart)
+- [Project Management Methodologies](https://www.wrike.com/project-management-guide/methodologies/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+
+---
+
+## Document Development Life Cycle (DDLC)
+
+**Definition**: process of writing and delivering content in the form
+of documentation such as PDFs, Word documents, online articles, or
+website content
+
+**Purpose**: provides a structured approach to creating documentation
+with well-defined phases that ensure content meets user needs
+
+**Phases**:
+
+1. Analysis and planning
+2. Designing
+3. Content development
+4. Proofreading and editing
+5. Publishing
+6. Implementation
+7. Approval
+8. Maintenance
+
+**Related Terms**: Agile, project management methodology, usability testing
+
+**Sources**:
+
+- [Geeks for Geeks: Document Development Life Cycle](https://www.geeksforgeeks.org/software-engineering/document-development-life-cycle-ddlc/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+
+---
+
+## Guerrilla Usability Testing
+
+**Definition**: evaluation method that tests interface effectiveness
+by approaching participants in public spaces for quick feedback rather
+than recruiting in advance
+
+**Purpose**: provides a quick, cost-effective way to gather feedback
+from target users without formal recruitment processes
+
+**Characteristics**:
+
+- Low maintenance with predefined tasks
+- Best for testing that doesn't require advanced device knowledge
+- Returns less accurate results than formal testing
+- Participants approached ad hoc in public settings
+
+**Deliverables**:
+
+- Test plan with timeframe and research objectives
+- Video with screen and participant recordings
+- Summary report with key findings and next steps
+- Presentation covering findings and recommendations
+
+**Related Terms**: AI-assisted usability analysis, usability testing
+
+**Sources**:
+
+- [Guerrilla Usability Testing: How To Introduce It In Your Next UX Project](https://usabilitygeek.com/guerrilla-usability-testing-how-to/)
+- UW API Docs - Module 4, Lesson 3, "Review usability testing for API"
+
+---
+
+## project management methodology
+
+**Definition**: different approaches to organizing and executing projects,
+ranging from sequential to iterative frameworks
+
+**Purpose**: provides structured ways to plan, execute, and complete
+projects based on team needs and project characteristics
+
+**Common Methodologies**:
+
+| Methodology | Approach | Focus | Best For |
+| ------------- | ---------- | ------- | ---------- |
+| Waterfall | Sequential, linear | Phase completion | Stable requirements, predictable projects |
+| Critical Path Method | Dependency-based | Task sequences | Projects with clear dependencies |
+| Critical Chain Project Management | Resource-focused | Resource availability | Resource-constrained projects |
+| Agile | Iterative, flexible | Adaptation | Changing requirements, feedback loops |
+| Scrum | Sprint-based | Team collaboration | Fast-paced development, quick iterations |
+
+**Related Terms**: Agile, Critical Chain Project Management,
+Critical Path Method, Document Development Life Cycle, Scrum, Waterfall
+
+**Sources**:
+
+- [Project Management Methodologies](https://www.wrike.com/project-management-guide/methodologies/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+
+---
+
+## Scrum
+
+**Definition**: Agile framework where small teams led by a scrum master
+work in short two-week cycles called sprints with daily meetings
+
+**Purpose**: enables rapid development and testing while removing
+obstacles to efficient work
+
+**Characteristics**:
+
+- Scrum master clears obstacles to team efficiency
+- Work completed in two-week sprints
+- Daily team meetings to discuss progress
+- Iterative approach to development
+
+**Related Terms**: Agile, project management methodology
+
+**Sources**:
+
+- [Project Management Methodologies](https://www.wrike.com/project-management-guide/methodologies/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+
+---
+
+## usability testing
+
+**Definition**: practice of testing how easy a design is to use with
+representative users, typically by observing them as they attempt to
+complete tasks
+
+**Purpose**: identifies problems before customers encounter them and
+provides user perspective before product release
+
+**Benefits**:
+
+- Finds problems before customers do
+- Provides customer perspective pre-release
+- Informs design improvements
+
+**Limitations**:
+
+- Not designed to generalize beyond test scope
+- Can't prove that a feature works universally
+- Not statistically significant but still useful
+- Participant recruitment is challenging
+
+**Related Terms**: AI-assisted usability analysis, Guerrilla Usability Testing
+
+**Source**: UW API Docs - Module 4, Lesson 3, "Review usability testing for API"
+
+---
+
+## Waterfall
+
+**Definition**: traditional, sequential, linear project management
+methodology where each phase must complete before the next begins
+
+**Purpose**: provides simple, idealistic approach for projects with
+well-defined requirements and minimal expected changes
+
+**Characteristics**:
+
+- Sequential, non-iterative phases
+- First introduced by Winston W. Royce in 1970
+- Each phase gates the next
+- Limited flexibility for changes
+
+**Related Terms**: Agile, project management methodology, Scrum
+
+**Sources**:
+
+- [Project Management Methodologies](https://www.wrike.com/project-management-guide/methodologies/)
+- UW API Docs - Module 2, Lesson 3, "Introduction to Project Scheduling"
+- [Waterfall Model - Software Engineering](https://www.geeksforgeeks.org/software-engineering/waterfall-model/)
+
+---

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -11,11 +11,11 @@ const sidebars: SidebarsConfig = {
   tutorialSidebar: [
     'introduction',
     'getting-started',
-    'core-concepts',
     'quick-reference',
+    'core-concepts',
     'frameworks-strategy',
     'tools-techniques',
-    'processes',
+    'workflows-methodologies',
     'writing-style',
     'ai-and-apis',
     'style-guide',


### PR DESCRIPTION
- Resolves Issue #46 
- Renames “processes” to “workflows and methodologies”
- Added line breaks for each term entry
- Keep sources list as **Sources** and not _Sources_